### PR TITLE
Fix base filename for example: "test"->"book"

### DIFF
--- a/_data/examples.yml
+++ b/_data/examples.yml
@@ -1,6 +1,6 @@
 basic:
   - {fn: "simple", source: "simple.sil", title: "Basic typesetting" }
-  - {fn: "test", source: "test.sil", title: "A Story" }
+  - {fn: "book", source: "book.sil", title: "A Story" }
 global:
   -
     fn: global-scripts/i18n


### PR DESCRIPTION
It seems the input & output files were renamed here: https://github.com/sile-typesetter/sile/pull/595/files#diff-b9e24dfa5798b16d8ea714c3edbf346f

Will hopefully un-break the "A Story" example here: https://sile-typesetter.org/examples/
