### PR TITLE
Cleanup Mongolian example and mark as devel only

### DIFF
--- a/content/examples/mongolian.sil
+++ b/content/examples/mongolian.sil
@@ -1,9 +1,8 @@
-\begin[papersize=a5]{document}
+\begin[papersize=a5,direction=TTB-LTR]{document}
 \bidi-off
 \nofolios
-\neverindent
-\thisframedirection[direction=TTB-LTR]
-\font[family=Mongolian White,size=24pt,direction=LTR]
+\language[main=mon]
+\font[family=Mongolian White,size=24pt]
 ᠡᠷᠲᠡ ᠤᠷᠢᠳᠠ ᠺᠠᠪᠠᠯᠢᠺ ᠪᠠᠯᠭᠠᠰᠤᠨ ᠳᠤᠷ ᠪᠢᠷᠠᠮᠠᠨ ᠤ ᠬᠠᠮᠤᠭ ᠤᠬᠠᠭᠠᠨ ᠤ ᠵᠦᠢᠯ ᠳᠦᠷ ᠮᠡᠷᠭᠡᠨ ᠪᠣᠯᠤᠭᠰᠠᠨ ᠰᠠᠢᠨ ᠲᠥᠷᠥᠯ ᠲᠦ ᠬᠡᠮᠡᠬᠦᠨᠢᠭᠡᠨ ᠪᠢᠷᠠᠮᠠᠨ ᠪᠦᠯᠦᠭᠡ᠃
 ᠲᠡᠷᠡ ᠪᠢᠷᠠᠮᠠᠨ ᠳᠤᠷ ᠰᠡᠳᠬᠢᠯ ᠳᠤᠷ ᠲᠠᠭᠠᠯᠠᠬᠤ ᠨᠡᠷᠡᠲᠦ ᠨᠢᠭᠡᠨ ᠬᠠᠲᠤᠭᠲᠠᠢ ᠪᠦᠯᠦᠭᠡ᠃
 ᠲᠡᠷᠡ ᠬᠣᠶᠠᠷᠠᠴᠠ ᠨᠢᠭᠡᠨ ᠬᠥᠪᠡᠭᠦᠨ ᠲᠥᠷᠥᠵᠦᠬᠦᠢ᠃

--- a/data/examples.toml
+++ b/data/examples.toml
@@ -45,6 +45,7 @@ title = "Vertical Japanese with Ruby and inline Latin"
 
 [[global]]
 fn = "mongolian"
+devel = true
 source = "mongolian.sil"
 title = "Mongolian - top to bottom, left to right"
 


### PR DESCRIPTION
Broken in last stable release, fixed in master

c.f. https://github.com/sile-typesetter/sile/issues/1472