### PR TITLE
Fix font name in javanese example

### DIFF
--- a/content/examples/javanese.sil
+++ b/content/examples/javanese.sil
@@ -1,7 +1,7 @@
 \begin[papersize=a5]{document}
 \nofolios
 \neverindent
-\font[family=Tuladha Jejeg,language=jv]
+\font[family=Tuladha Jejeg OT,language=jv]
 \begin{raggedright}
 \font[size=24pt]{ꦥꦺꦔꦼꦠ꧀ꦠꦤ꧀}
 


### PR DESCRIPTION
The Javanese example displayed on the website (https://sile-typesetter.org/examples/global/) is currently broken. Because the font cannot be found.

This PR fixes the name of the font (so as to match what is installed at build time) hence fixes the rendering of the Javanese parts. Unfortunately, said font does not seem to have any glyph for Arabic numerals. I’m not sure what would be an acceptable fix here.

