### PR TITLE
Add more wow effect to the rule example

### DIFF
--- a/content/examples/rule.sil
+++ b/content/examples/rule.sil
@@ -3,10 +3,30 @@
 \use[module=packages.rules]
 \use[module=packages.raiselower]
 \font[size=14pt]
-S\glue[width=-0.1en]\raise[height=-0.5ex]{\font[size=9pt]{I}}\glue[width=-0.1en]L\glue[width=-0.4en]\raise[height=0.5ex]{\font[size=7pt]{E}}
-comes with a number of packages which provide additional functionality.
 
-A box: \raise[height=1ex]{\hrule[width=3em, height=0.4pt]} here.
+“Rules” are rectangular ink blobs that can be be used to create a variety of effects.
 
-Test \underline{underlining several words}.
+\fullrule
+
+Simple rectangular boxes are easy. QED \hrule[height=1ex, width=1ex]
+
+\noindent\hfill\raise[height=0.5ex]{\hrule[width=25%lw, height=0.4pt]}\hfill
+
+One can also underline \underline{content} or strike \strikethrough{content}.
+These can be nested and can span multiple lines as paragraphs are line-wrapped:
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. \underline{Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor}. \strikethrough{Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.} Duis semper. Duis arcu massa, \underline{scelerisque \strikethrough{vita} vitae}, consequat in, pretium a, enim.
+
+\noindent\hfill\raise[height=0.5ex]{\hrule[width=25%lw, height=0.4pt]}\hfill
+
+Rule “fills” stretch to the available width of the line.
+
+Placeholder for some input: \hrulefill[position=underline].
+
+\medskip
+Obviously, the following example is just for the Wow! factor.
+There are many ways to display a glider from Conway’s Game of Life, and this one is certainly not the most efficient and elegant!
+
+\noindent\hrulefill[raise=9pt, thickness=1pt]\glue[width=2pt]\rebox[height=20pt]{\hrule[height=5pt, width=5pt]\glue[width=1pt]\hrule[height=5pt, width=5pt]\glue[width=1pt]\hrule[height=5pt, width=5pt]\glue[width=-5pt]\raise[height=6pt]{\hrule[height=5pt, width=5pt]}%
+\glue[width=-11pt]\raise[height=12pt]{\hrule[height=5pt, width=5pt]}}\glue[width=9pt]\hrulefill[raise=9pt, thickness=1pt]
+
 \end{document}


### PR DESCRIPTION
Just looking at the current "rule" example, I found it quite unimpressive.
 - It uses the unofficial SILE logo ("à la TeX raised and lowered letters"), which I don't find that nice (and anyway this would be a demonstration of raiselower, not rules...)
 - As of "rules", it just shows two very simple lines.

This PR is a proposal to have some more effects included, and even a bit of Wow! factor (as far as one can achieve something with very low-level primitives :rofl:) 

My assumption is that people don't really check these examples for anything else than to have a quick demonstration and showcase of SILE capabilities, so whatever goes in this example sections, it should be nice and minimally impressive.

![image](https://github.com/user-attachments/assets/a7f59490-3607-41dd-88fb-356feeb3fa35)


